### PR TITLE
Configure new relic app name

### DIFF
--- a/docs/HEROKU.md
+++ b/docs/HEROKU.md
@@ -25,12 +25,13 @@ Once the app is running locally, and while still in the app directory, execute t
   1. `$ heroku addons:add papertrail`
   1. `$ heroku addons:add librato --logs`
   1. `$ heroku addons:add honeybadger`
+  1. `$ heroku addons:add newrelic:standard`
 1. Enable recommended lab features
   1. `$ heroku labs:enable user-env-compile`
   1. `$ heroku labs:enable log-runtime-metrics`
 1. Set config:
 ```
-$ heroku config:set SECRET_TOKEN=`openssl rand -base64 32` RACK_ENV=production RUBY_GC_MALLOC_LIMIT=90000000 WEB_CONCURRENCY=2 NEW_RELIC_APP_NAME=discourse
+$ heroku config:set SECRET_TOKEN=`openssl rand -base64 32` RACK_ENV=production RUBY_GC_MALLOC_LIMIT=90000000 WEB_CONCURRENCY=2 NEW_RELIC_APP_NAME=Discourse
 ```
 1. Deploy and scale
   1. `$ git push heroku master` (this initial deploy can take some time due to the extensive dependency list and asset compilation for an app of Discourse's size)


### PR DESCRIPTION
NEW_RELIC_APP_NAME must be defined in order for newrelic.yml to work.

Since this seems to be a start-to-finish guide to getting discourse up, I think it makes sense to include this, even though it's in the existing [heroku new relic documentation](https://devcenter.heroku.com/articles/newrelic).

I was surprised to find that the heroku's environment doesn't already include it's app name.
