### PR TITLE
Update New Relic addon instructions

### DIFF
--- a/docs/HEROKU.md
+++ b/docs/HEROKU.md
@@ -25,7 +25,7 @@ Once the app is running locally, and while still in the app directory, execute t
   1. `$ heroku addons:add papertrail`
   1. `$ heroku addons:add librato --logs`
   1. `$ heroku addons:add honeybadger`
-  1. `$ heroku addons:add newrelic:standard`
+  1. `$ heroku addons:add newrelic:stark`
 1. Enable recommended lab features
   1. `$ heroku labs:enable user-env-compile`
   1. `$ heroku labs:enable log-runtime-metrics`


### PR DESCRIPTION
`newrelic:standard` appears to be deprecated; in the docs, this replaces it with `newrelic:stark` (the more fully-featured of the two free New Relic tiers)
